### PR TITLE
[Fix] Add remove array item NPC

### DIFF
--- a/Editor/level_scene/lvl_control.cpp
+++ b/Editor/level_scene/lvl_control.cpp
@@ -285,6 +285,13 @@ void LvlScene::mouseReleaseEvent(QGraphicsSceneMouseEvent *mouseEvent)
                             ((ItemBGO *)(*it))->removeFromArray();
                             deleted=true;
                         }
+                        else
+                        if( (*it)->data(0).toString()=="NPC" )
+                        {
+                            historyBuffer.npc.push_back(((ItemNPC*)(*it))->npcData);
+                            ((ItemNPC *)(*it))->removeFromArray();
+                            deleted=true;
+                        }
 
                         removeItem((*it)); continue;
                     }


### PR DESCRIPTION
Without it, the item would be removed from scene, but not from array.
And now it records also NPC for history!
