### PR TITLE
Remove "this->hide();" in MainWindow.cpp

### DIFF
--- a/Editor/mainwindow.cpp
+++ b/Editor/mainwindow.cpp
@@ -143,10 +143,10 @@ void MainWindow::on_actionRefresh_menu_and_toolboxes_triggered()
 void MainWindow::on_actionSwitch_to_Fullscreen_triggered(bool checked)
 {
     if(checked){
-        this->hide();
+        //this->hide();
         this->showFullScreen();
     }else{
-        this->hide();
+        //this->hide();
         this->showNormal();
     }
 }


### PR DESCRIPTION
I noticed that under Linux Mint, after building with those two lines missing I was able to enable fullscreen without any color bugs at all. I'm not entirely sure what the purpose of this->hide is since I know absolutely 0 C++ but it seems as though all it would do is hide the window. If this is necessary for other OS'es (I'll try and test later) then we could always attempt to implement a one second timer before switching to fullscreen.
